### PR TITLE
Fetch Missing Attachments issue cause calendar component now shown

### DIFF
--- a/app/src/flux/stores/message-store.es6
+++ b/app/src/flux/stores/message-store.es6
@@ -649,7 +649,8 @@ class MessageStore extends MailspringStore {
                   accountId: i.accountId,
                   missingItems: inLineMissing,
                 });
-              } else if (normalMissing.length > 0) {
+              }
+              if (normalMissing.length > 0) {
                 Actions.fetchAttachments({
                   accountId: i.accountId,
                   missingItems: normalMissing,
@@ -669,6 +670,12 @@ class MessageStore extends MailspringStore {
           if (change) {
             if (inLineMissing.length > 0) {
               Actions.fetchAttachments({ accountId: i.accountId, missingItems: inLineMissing });
+            }
+            if (normalMissing.length > 0) {
+              Actions.fetchAttachments({
+                accountId: i.accountId,
+                missingItems: normalMissing,
+              });
             }
             this._missingAttachmentIds = [...inLineMissing, ...normalMissing];
             this.trigger();


### PR DESCRIPTION
changed fetch missing attachment logic to auto fetch both inline AND normal attachments.

Before, not downloading ics files was causing parsing calendar to fail