### PR TITLE
fix the wrong caret position while input the first character in the composer editor under chinese IME 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ client_secret.json
 /app/mailsync.dSYM
 
 .idea
+.vscode

--- a/app/src/components/slate-react/plugins/before.js
+++ b/app/src/components/slate-react/plugins/before.js
@@ -192,7 +192,11 @@ function BeforePlugin() {
     }
 
     debug('onCompositionStart', { event: event });
-    // return change.insertText('\u200b');
+    const sel = window.getSelection()
+    const range = sel.getRangeAt(0)
+    if (range && range.startContainer!==range.endContainer) {
+      change.insertText('\u200b');
+    }
     return true
   }
 


### PR DESCRIPTION
only remove out "change.insertText('\u200b')" to fix the caret positio, keep prior fix on composer crash under chinese ime.