### PR TITLE
Revert "DC-1867 change all folder font to 12px in accordance with spec"

### DIFF
--- a/app/static/components/outline-view.less
+++ b/app/static/components/outline-view.less
@@ -238,7 +238,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       color: @text-color-very-subtle;
-      font-size: 12px;
+      font-size: 14px;
       letter-spacing: 0.17px;
       line-height: 28px;
       white-space: nowrap;
@@ -250,7 +250,7 @@
       height: 14px;
       width: fit-content;
       color: @gray-light;
-      font-size: 12px;
+      font-size: 14px;
       letter-spacing: -0.26px;
       line-height: 14px;
     }


### PR DESCRIPTION
Reverts agent8/Mailspring#532
Hilary agrees we should use 14px for folder text