### PR TITLE
DC-2041 [Office365] Wrong folder name saved for Office365

### DIFF
--- a/app/src/mailbox-perspective.es6
+++ b/app/src/mailbox-perspective.es6
@@ -383,9 +383,11 @@ export default class MailboxPerspective {
           accountId: category.accountId,
           path: category.path.replace('[Gmail]/', ''),
           displayName: category.displayName,
+          role: category.role,
         });
       } else {
         ret.push({
+          role: category.role,
           accountId: category.accountId,
           path: category.path,
           parentId: category.parentId,


### PR DESCRIPTION
We did not pass role into paths in mailboxperspective