### PR TITLE
DC-2228 copy email address in message detail

### DIFF
--- a/app/internal_packages/message-list/lib/message-participants.jsx
+++ b/app/internal_packages/message-list/lib/message-participants.jsx
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import classnames from 'classnames';
 import { React, PropTypes, Actions } from 'mailspring-exports';
-import { remote } from 'electron';
+import { remote, clipboard } from 'electron';
 
 const { Menu, MenuItem } = remote;
 const MAX_COLLAPSED = 5;
@@ -79,6 +79,12 @@ export default class MessageParticipants extends React.Component {
   _onContactContextMenu = (contact, e) => {
     const menu = new Menu();
     menu.append(new MenuItem({ role: 'copy' }));
+    menu.append(
+      new MenuItem({
+        label: 'Copy Address',
+        click: () => clipboard.writeText(contact.email)
+      })
+    );
     menu.append(
       new MenuItem({
         label: `Email ${contact.email}`,


### PR DESCRIPTION
This PR includes:
- Added MenuItem to write email address to clipboard
![EdisonMail_·_Welcome_To_Spark](https://user-images.githubusercontent.com/24506190/88129948-e95b4200-cc0b-11ea-906c-799507e780e2.png)
