### PR TITLE
DC-2270 Fix issue with sending RestorDraftTask after SendDraftTask failed

### DIFF
--- a/app/src/flux/stores/draft-editing-session.es6
+++ b/app/src/flux/stores/draft-editing-session.es6
@@ -468,6 +468,7 @@ export default class DraftEditingSession extends MailspringStore {
       this._draft &&
       !this._draft.savedOnRemote &&
       this._draft.refOldDraftMessageId &&
+      !Message.compareMessageState(this._draft.syncState, Message.messageSyncState.failed) &&
       AppEnv.isMainWindow()
     ) {
       const task = new RestoreDraftTask({


### PR DESCRIPTION
We should not restore draft send draft failed for server draft 