### PR TITLE
Fix issue with missing is-hotkey module

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
     "ical.js": "^1.3.0",
     "immutable": "^3.8.2",
     "integer": "2.1.0",
+    "is-hotkey": "^0.1.6",
     "is-online": "7.0.0",
     "jasmine-json": "~0.0",
     "jasmine-react-helpers": "^0.2",


### PR DESCRIPTION
fix issue with not able to properly import is-hotkey in slate-edit-code/onKeyDown.js