### PR TITLE
UI fix: the icon of account folder mapper can't seen

### DIFF
--- a/app/internal_packages/category-picker/styles/category-picker.less
+++ b/app/internal_packages/category-picker/styles/category-picker.less
@@ -95,6 +95,12 @@ body.platform-win32 {
   }
   .category-item {
     width: 140px;
+    padding-left: 0;
+    display: flex;
+    .edison-icon {
+      margin-right: 6px;
+      color: @gray-light;
+    }
   }
 }
 

--- a/app/internal_packages/composer/lib/composer-header-actions.jsx
+++ b/app/internal_packages/composer/lib/composer-header-actions.jsx
@@ -52,7 +52,7 @@ export default class ComposerHeaderActions extends React.Component {
           key="subject"
           onClick={() => this.props.onShowAndFocusField(Fields.Subject)}
         >
-          SUBJECT
+          SUBJ
         </span>
       );
     }

--- a/app/internal_packages/preferences/lib/components/category-selection.jsx
+++ b/app/internal_packages/preferences/lib/components/category-selection.jsx
@@ -62,10 +62,18 @@ export default class CategorySelection extends React.Component {
       icon = <div className="empty-icon" />;
       item.path = '(None)';
     } else {
+      let iconName = item.name.toLowerCase();
+      if (iconName === 'deleted') {
+        iconName = 'trash';
+      } else if (!['sent', 'drafts', 'junk', 'archive', 'trash'].includes(iconName)) {
+        iconName = item.isLabel() ? 'label' : 'folder';
+      }
       icon = (
         <RetinaImg
-          name={`${item.name}.png`}
-          fallback={item.isLabel() ? 'tag.png' : 'folder.png'}
+          isIcon
+          name={`${iconName}.svg`}
+          fallback={item.isLabel() ? 'label.svg' : 'folder.svg'}
+          style={{ width: 20, height: 20 }}
           mode={RetinaImg.Mode.ContentIsMask}
         />
       );
@@ -73,6 +81,7 @@ export default class CategorySelection extends React.Component {
 
     const displayPath = item.name || utf7.imap.decode(item.path);
 
+    console.log('****icon', icon);
     return (
       <div className="category-item">
         {icon}

--- a/app/internal_packages/preferences/lib/components/category-selection.jsx
+++ b/app/internal_packages/preferences/lib/components/category-selection.jsx
@@ -81,7 +81,6 @@ export default class CategorySelection extends React.Component {
 
     const displayPath = item.name || utf7.imap.decode(item.path);
 
-    console.log('****icon', icon);
     return (
       <div className="category-item">
         {icon}


### PR DESCRIPTION
UI fix: the icon of account folder mapper can't seen
DC-2497 Add the subject to the templates feature